### PR TITLE
Fix team note update

### DIFF
--- a/src/PyHackMD/api.py
+++ b/src/PyHackMD/api.py
@@ -253,7 +253,7 @@ class API():
         }
         data = self.__remove_none(data)
         res = self.__request(self.__Method.PATCH, full_api)
-        return self.__get_result(res)
+        return self.__get_result(res, json_format=False)
 
     def delete_team_note(self, team_path: str, note_id: str):
         '''Delete a team note

--- a/src/PyHackMD/api.py
+++ b/src/PyHackMD/api.py
@@ -252,7 +252,7 @@ class API():
             'permalink': ''
         }
         data = self.__remove_none(data)
-        res = self.__request(self.__Method.PATCH, full_api)
+        res = self.__request(self.__Method.PATCH, full_api, data)
         return self.__get_result(res, json_format=False)
 
     def delete_team_note(self, team_path: str, note_id: str):


### PR DESCRIPTION
Like [`update_note`](https://github.com/eugene87222/python-HackMD/blob/main/src/PyHackMD/api.py#L150), `update_team_note` shouldn't parse the response as JSON. ([API documentation](https://hackmd.io/@hackmd-api/team-notes-api#Update-a-note-in-a-Team%E2%80%99s-workspace) for reference.)

Also added missing `data` to the API request.